### PR TITLE
Minify espup installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ check_version_formatting "$version"
 # formatted following (our extended version of) semver is provided, attempt to
 # install that version of the compiler.
 
-$HOME/.cargo/bin/espup install -l debug --export-file $HOME/exports --targets ${buildtargets} --toolchain-version $version
+$HOME/.cargo/bin/espup install -l debug --profile-minimal --export-file $HOME/exports --targets ${buildtargets} --toolchain-version $version
 
 # With the required exports specified by the rust-build installation script
 # saved to a file, we can simply `source` it to export said variables. GitHub


### PR DESCRIPTION
Use `--profile-minimal` argument as it  can save some time of installation, mainly because it will use [`libs` instead of the whole LLVM (37.5 MB vs 200 MB)](https://github.com/espressif/llvm-project/releases/tag/esp-15.0.0-20221201)

Sorry, I just noticed it!