### PR TITLE
Fix `ldproxy` condition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Check environmnent
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         name: Install Xtensa Rust
         with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: rustup update stable && rustup default stable
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         name: Install Xtensa Rust
         with:

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Install ldproxy
-      if: inputs.ldproxy
+      if: inputs.ldproxy == 'true'
       shell: bash
       run: |
         curl -L https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip -o $HOME/.cargo/bin/ldproxy.zip


### PR DESCRIPTION
`ldproxy` was always being installed. Eg: In `esp-hal` [it shouldn't be installed](https://github.com/esp-rs/esp-hal/blob/main/.github/workflows/ci.yml#L38) but it is [still installed](https://github.com/esp-rs/esp-hal/actions/runs/4666750463/jobs/8261707590#step:3:12). With this change, the `ldproxy` condition is evaluated fine: In CI [`ldproxy` is `false`](https://github.com/SergioGasquez/xtensa-toolchain/blob/main/.github/workflows/ci.yaml#L22) and here [the resulting action skips it ](https://github.com/SergioGasquez/xtensa-toolchain/actions/runs/4688908481/jobs/8309989436#step:3:12).