### PR TITLE
Make the action work with `act`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ So, we recommend [defining] `GITHUB_TOKEN`, as seen in the [example workflow], w
 [defining]: https://docs.github.com/en/actions/learn-github-actions/variables
 [example workflow]: #example-workflow
 
+## Use with [act]
+
+[act] is a tool which can be used to run GitHub workflows locally, using Docker. It is possible to use the `xtensa-toolchain` action with [act]; however, due to the fact that [espup] queries the GitHub API, it is necessary to set the `GITHUB_TOKEN` environment variable in order to do so.
+
+For more information please see the [`GITHUB_TOKEN`] section of the `README` for [act].
+
+[act]: https://github.com/nektos/act
+[`GITHUB_TOKEN`]: https://github.com/nektos/act#github_token
+
 ## License
 
 Licensed under either of:

--- a/action.yaml
+++ b/action.yaml
@@ -26,25 +26,35 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Ensure that Rust is already installed
+      shell: bash
+      run: |
+        if [ ! -d "$HOME/.cargo/bin" ]; then
+          curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal -y
+        fi
+
     - name: Install ldproxy
       if: inputs.ldproxy == 'true'
       shell: bash
       run: |
-        curl -L https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip -o $HOME/.cargo/bin/ldproxy.zip
-        unzip "$HOME/.cargo/bin/ldproxy.zip" -d "$HOME/.cargo/bin/"
-        chmod a+x $HOME/.cargo/bin/ldproxy
+        curl -LO https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip
+        unzip ldproxy-x86_64-unknown-linux-gnu.zip -d "$HOME/.cargo/bin"
+        chmod a+x "$HOME/.cargo/bin/ldproxy"
+
     - name: Install espup
       shell: bash
       run: |
-        curl -L https://github.com/esp-rs/espup/releases/latest/download/espup-x86_64-unknown-linux-gnu  -o $HOME/.cargo/bin/espup
-        chmod a+x $HOME/.cargo/bin/espup
+        curl -L https://github.com/esp-rs/espup/releases/latest/download/espup-x86_64-unknown-linux-gnu -o "$HOME/.cargo/bin/espup"
+        chmod a+x "$HOME/.cargo/bin/espup"
+
     - name: Install Xtensa toolchain
       shell: bash
       run: |
+        source "$HOME/.cargo/env"
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        $HOME/.cargo/bin/espup install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
+        "$HOME/.cargo/bin/espup" install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
         source "$HOME/exports"
-        echo "$PATH" >>"$GITHUB_PATH"
-        echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >>"$GITHUB_ENV"
+        echo "$PATH" >> "$GITHUB_PATH"
+        echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
         [[ "${{ inputs.default }}" = true ]] && rustup default esp || true
         [[ "${{ inputs.override }}" = true ]] && rustup override unset || true


### PR DESCRIPTION
Previously it was not possible to use this action with [act](https://github.com/nektos/act). This was because of two reasons:

1. This action assumed that `$HOME/.cargo/bin` already existed, which was not the case in the container image used by `act`
2. `espup` requires a valid Rust installation, which, as mentioned in the previous point, is not present by default

The fix for this is fairly easy, and that is to ensure Rust is installed first. If there is an existing installation no additional work is performed compared with the previous version.

I have also noted the need to provide a `GITHUB_TOKEN` environment variable when using this action with `act`.

Additionally, I've done a bit of random cleanup/improvements. Nothing worth noting, really.