### PR TITLE
Override ldproxy install without prompting

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
       shell: bash
       run: |
         curl -LO https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip
-        unzip ldproxy-x86_64-unknown-linux-gnu.zip -d "$HOME/.cargo/bin"
+        unzip -o ldproxy-x86_64-unknown-linux-gnu.zip -d "$HOME/.cargo/bin"
         chmod a+x "$HOME/.cargo/bin/ldproxy"
 
     - name: Install espup


### PR DESCRIPTION
When running this action again on the same runner, it fails when unzipping `ldproxy` because it asks if it should override existing file: 
<img width="723" alt="image" src="https://github.com/user-attachments/assets/a86f3eaa-2350-4987-b7da-f0d671f2981c">

This PR just adds the `-o` flag to the `unzip` command, telling it to overwrite without prompting.