### PR TITLE
Fix how rustup is verified/installed

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,8 +29,10 @@ runs:
     - name: Ensure that Rust is already installed
       shell: bash
       run: |
-        if [ ! -d "$HOME/.cargo/bin" ]; then
+        if ! command -v rustup &> /dev/null; then
           curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal -y
+          export PATH="$HOME/.cargo/bin:$PATH"
+          echo "PATH=$PATH" >> $GITHUB_ENV
         fi
 
     - name: Detect host target triple


### PR DESCRIPTION
https://github.com/esp-rs/esp-hal/actions/runs/13109391906/job/36569814277?pr=3072 occurred because Rust is not present, its installed by the action but the path is not updated, hence the next steps couldn't find the binary

This didnt occurred in the CI checks of the action as the gh-hosted-runners already have rust installed

esp-hal test:  https://github.com/esp-rs/esp-hal/actions/runs/13110802777