### PR TITLE
Only export LIBCLANG_PATH when override=true

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -66,7 +66,7 @@ runs:
         "$HOME/.cargo/bin/espup" install -l debug --targets ${{ inputs.buildtargets }} $version
         source "$HOME/exports"
         echo "$PATH" >> "$GITHUB_PATH"
-        echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
+        [[ "${{ inputs.override }}" = true ]] && echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV" || true
 
     - name: Install Xtensa toolchain (Windows)
       if: env.HOST_TARGET == 'x86_64-pc-windows-msvc'

--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,7 @@ runs:
         curl -LO https://github.com/esp-rs/espup/releases/latest/download/espup-${{ env.HOST_TARGET }}.zip
         unzip -o espup-${{ env.HOST_TARGET }}.zip -d "$HOME/.cargo/bin"
         chmod +x "$HOME/.cargo/bin/espup"*
+        echo "ESPUP_EXPORT_FILE=$HOME/exports" >> $GITHUB_ENV
 
     - name: Install Xtensa toolchain (Linux, macOS)
       if: env.HOST_TARGET != 'x86_64-pc-windows-msvc'
@@ -62,7 +63,7 @@ runs:
       run: |
         source "$HOME/.cargo/env"
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup" install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
+        "$HOME/.cargo/bin/espup" install -l debug --targets ${{ inputs.buildtargets }} $version
         source "$HOME/exports"
         echo "$PATH" >> "$GITHUB_PATH"
         echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
@@ -72,7 +73,7 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup.exe" install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
+        "$HOME/.cargo/bin/espup.exe" install -l debug --targets ${{ inputs.buildtargets }} $version
 
     - name: Set default and override
       shell: bash


### PR DESCRIPTION
Closes: https://github.com/esp-rs/xtensa-toolchain/issues/35

This is the simple approach (reusing the `override` tunable); discussion in #35 will need to show whether that is an acceptable change, or whether a new tunable is needed.