### PR TITLE
Export ESPUP_EXPORT_FILE

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,7 @@ runs:
         curl -LO https://github.com/esp-rs/espup/releases/latest/download/espup-${{ env.HOST_TARGET }}.zip
         unzip -o espup-${{ env.HOST_TARGET }}.zip -d "$HOME/.cargo/bin"
         chmod +x "$HOME/.cargo/bin/espup"*
+        echo "ESPUP_EXPORT_FILE=$HOME/exports" >> $GITHUB_ENV
 
     - name: Install Xtensa toolchain (Linux, macOS)
       if: env.HOST_TARGET != 'x86_64-pc-windows-msvc'
@@ -62,7 +63,7 @@ runs:
       run: |
         source "$HOME/.cargo/env"
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup" install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
+        "$HOME/.cargo/bin/espup" install -l debug --targets ${{ inputs.buildtargets }} $version
         source "$HOME/exports"
         echo "$PATH" >> "$GITHUB_PATH"
         echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
@@ -72,7 +73,7 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup.exe" install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
+        "$HOME/.cargo/bin/espup.exe" install -l debug --targets ${{ inputs.buildtargets }} $version
 
     - name: Set default and override
       shell: bash


### PR DESCRIPTION
This is primarily useful for hands-off environments where the paths are not exported by default (i.e., any solution to #35, be it #36 or #38-to-be), and conveniently allows eliding the parameter during installation (because the variable is used by espup).

Even without those downstream PRs, this should be good refactoring.