### PR TITLE
Only export LIBCLANG_PATH when export=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This action can be configured in various ways using its inputs:
 |   `version`    |     Which version of the toolchain to install     | string | _latest_ |
 |   `ldproxy`    | Whether to install `ldproxy` (required for `std`) |  bool  |  `true`  |
 |   `override`   |         Overrides the installed toolchain         |  bool  |  `true`  |
+|    `export`    |           Sources `${ESPUP_EXPORT_FILE}`          |  bool  |  `true`  |
 
 All inputs are optional; if no inputs are provided:
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,9 @@ inputs:
   override:
     description: Whether to override the toolchain
     default: true
+  export:
+    description: Whether to export the `${ESPUP_EXPORT_FILE}` into the GitHub environment
+    default: true
 
 runs:
   using: composite
@@ -65,8 +68,10 @@ runs:
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
         "$HOME/.cargo/bin/espup" install -l debug --targets ${{ inputs.buildtargets }} $version
         source "$HOME/exports"
-        echo "$PATH" >> "$GITHUB_PATH"
-        echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
+        if [[ "${{ inputs.export }}" = true ]]; then
+            echo "$PATH" >> "$GITHUB_PATH"
+            echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
+        fi
 
     - name: Install Xtensa toolchain (Windows)
       if: env.HOST_TARGET == 'x86_64-pc-windows-msvc'

--- a/action.yaml
+++ b/action.yaml
@@ -55,6 +55,7 @@ runs:
         curl -LO https://github.com/esp-rs/espup/releases/latest/download/espup-${{ env.HOST_TARGET }}.zip
         unzip -o espup-${{ env.HOST_TARGET }}.zip -d "$HOME/.cargo/bin"
         chmod +x "$HOME/.cargo/bin/espup"*
+        echo "ESPUP_EXPORT_FILE=$HOME/exports" >> $GITHUB_ENV
 
     - name: Install Xtensa toolchain (Linux, macOS)
       if: env.HOST_TARGET != 'x86_64-pc-windows-msvc'
@@ -62,7 +63,7 @@ runs:
       run: |
         source "$HOME/.cargo/env"
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup" install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
+        "$HOME/.cargo/bin/espup" install -l debug --targets ${{ inputs.buildtargets }} $version
         source "$HOME/exports"
         echo "$PATH" >> "$GITHUB_PATH"
         echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
@@ -72,7 +73,7 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup.exe" install -l debug --export-file $HOME/exports --targets ${{ inputs.buildtargets }} $version
+        "$HOME/.cargo/bin/espup.exe" install -l debug --targets ${{ inputs.buildtargets }} $version
 
     - name: Set default and override
       shell: bash


### PR DESCRIPTION
This is a solution to #35 that does not interfere with any existing deployments by creating a new option; it is an alternative to #36 and somehow builds on #37 (it doesn't strictly depend on #37, but any user of this will want #37 in).