### PR TITLE
Add option to install Extended LLVM installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Check environmnent
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         name: Install Xtensa Rust
         with:
@@ -28,11 +28,11 @@ jobs:
       - run: xtensa-esp32s3-elf-gcc --version
 
   check-arguments:
-    name: Check `buildtarget`, `version`, `override` and `ldproxy` arguments
+    name: Check `buildtarget`, `version`, `override`, `ldproxy`, and `extended-llvm` arguments
     runs-on: ubuntu-latest
     steps:
       - run: rustup update stable && rustup default stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         name: Install Xtensa Rust
         with:
@@ -40,23 +40,25 @@ jobs:
           ldproxy: true
           buildtargets: esp32,esp32c3
           version: 1.64.0.0
+          extended-llvm: true
       - run: rustc +esp --print target-list | grep xtensa
       - run: env | grep LIBCLANG_PATH
       - run: xtensa-esp32-elf-gcc --version
       - run: ls $HOME/.cargo/bin/ldproxy | grep ldproxy
       - run: cargo +esp --version | grep 1.64.0
       - run: rustup default | grep stable
+      - run: $CLANG_PATH --version | grep -i espressif
 
   check-host-targets:
     name: Check host | ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-         os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - run: rustup update stable && rustup default stable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         name: Install Xtensa Rust
       - run: rustc +esp --print target-list | grep xtensa

--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ jobs:
 
 This action can be configured in various ways using its inputs:
 
-|      Name      |                    Description                    |  Type  | Default  |
-| :------------: | :-----------------------------------------------: | :----: | :------: |
-|   `default`    |  Set installed toolchain as a default toolchain   |  bool  | `false`  |
-| `buildtargets` |          Comma separated list of targets          | string |  _all_   |
-|   `version`    |     Which version of the toolchain to install     | string | _latest_ |
-|   `ldproxy`    | Whether to install `ldproxy` (required for `std`) |  bool  |  `true`  |
-|   `override`   |         Overrides the installed toolchain         |  bool  |  `true`  |
-|    `export`    |           Sources `${ESPUP_EXPORT_FILE}`          |  bool  |  `true`  |
+|      Name       |                        Description                         |  Type  | Default  |
+| :-------------: | :--------------------------------------------------------: | :----: | :------: |
+|    `default`    |       Set installed toolchain as a default toolchain       |  bool  | `false`  |
+| `buildtargets`  |              Comma separated list of targets               | string |  _all_   |
+|    `version`    |         Which version of the toolchain to install          | string | _latest_ |
+|    `ldproxy`    |     Whether to install `ldproxy` (required for `std`)      |  bool  |  `true`  |
+|   `override`    |             Overrides the installed toolchain              |  bool  |  `true`  |
+|    `export`     |               Sources `${ESPUP_EXPORT_FILE}`               |  bool  |  `true`  |
+| `extended-llvm` | Install the whole LLVM instead of only installing the libs |  bool  | `false`  |
 
 All inputs are optional; if no inputs are provided:
 

--- a/action.yaml
+++ b/action.yaml
@@ -75,6 +75,7 @@ runs:
         if [[ "${{ inputs.export }}" = true ]]; then
             echo "$PATH" >> "$GITHUB_PATH"
             echo "LIBCLANG_PATH=${LIBCLANG_PATH}" >> "$GITHUB_ENV"
+            echo "CLANG_PATH=${CLANG_PATH}" >> "$GITHUB_ENV"
         fi
 
     - name: Install Xtensa toolchain (Windows)

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,9 @@ inputs:
   export:
     description: Whether to export the `${ESPUP_EXPORT_FILE}` into the GitHub environment
     default: true
+  extended-llvm:
+    description: Install the whole LLVM instead of only installing the libs
+    default: false
 
 runs:
   using: composite
@@ -66,7 +69,8 @@ runs:
       run: |
         source "$HOME/.cargo/env"
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup" install -l debug --targets ${{ inputs.buildtargets }} $version
+        [[ "${{ inputs.extended-llvm }}" = true ]] && extended_llvm="-e" || extended_llvm=""
+        "$HOME/.cargo/bin/espup" install -l debug --targets ${{ inputs.buildtargets }} $extended_llvm $version
         source "$HOME/exports"
         if [[ "${{ inputs.export }}" = true ]]; then
             echo "$PATH" >> "$GITHUB_PATH"
@@ -78,7 +82,8 @@ runs:
       shell: bash
       run: |
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
-        "$HOME/.cargo/bin/espup.exe" install -l debug --targets ${{ inputs.buildtargets }} $version
+        [[ "${{ inputs.extended-llvm }}" = true ]] && extended_llvm="-e" || extended_llvm=""
+        "$HOME/.cargo/bin/espup.exe" install -l debug --targets ${{ inputs.buildtargets }} $extended_llvm $version
 
     - name: Set default and override
       shell: bash


### PR DESCRIPTION
Users can now use `extended-llvm` to set the corresponding flag in `espup`. Closes #40