### PR TITLE
Add github-token input

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,6 @@ on:
   push:
   workflow_dispatch:
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   check-environment:
     name: Check environmnent
@@ -49,6 +46,48 @@ jobs:
       - run: cargo +xtensa --version | grep 1.64.0
       - run: rustup default | grep stable
       - run: $CLANG_PATH --version | grep -i espressif
+
+  check-github-token:
+    name: Check `github-token` | ${{ matrix.token.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # `espup` answers a bad credential with `401 Unauthorized` and fails, so
+        # whether the install succeeds tells us which token was actually used.
+        token:
+          - name: input overrides GITHUB_TOKEN
+            use-input: true
+            env: invalid-token-used-on-purpose
+            expected: success
+          - name: GITHUB_TOKEN used when input is empty
+            use-input: false
+            env: invalid-token-used-on-purpose
+            expected: failure
+          - name: falls back to github.token
+            use-input: false
+            env: ""
+            expected: success
+    steps:
+      - run: rustup update stable && rustup default stable
+      - uses: actions/checkout@v4
+      - uses: ./
+        id: install
+        name: Install Xtensa Rust
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ matrix.token.env }}
+        with:
+          # github.token cannot be read in the matrix, only available in steps
+          github-token: ${{ matrix.token.use-input && github.token || '' }}
+          buildtargets: esp32
+          ldproxy: false
+      - name: Check the install outcome
+        run: |
+          echo "outcome: ${{ steps.install.outcome }}, expected: ${{ matrix.token.expected }}"
+          [[ "${{ steps.install.outcome }}" = "${{ matrix.token.expected }}" ]]
+      - if: matrix.token.expected == 'success'
+        run: rustc +esp --print target-list | grep xtensa
 
   check-host-targets:
     name: Check host | ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ name: CI
 
 on: [push]
 
-# Since `espup` queries the GitHub API, we strongly recommend you provide this
-# action with an API token to avoid transient errors.
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   check:
     name: Rust project
@@ -57,7 +52,7 @@ This action can be configured in various ways using its inputs:
 |    `export`     |               Sources `${ESPUP_EXPORT_FILE}`               |  bool  |         `true`          |
 | `extended-llvm` | Install the whole LLVM instead of only installing the libs |  bool  |         `false`         |
 |     `name`      |                 Xtensa Rust toolchain name                 | string |          _esp_          |
-| `github-token`  |        Token used by `espup` to query the GitHub API       | string |  `${{ github.token }}`  | 
+|  `github-token` |       Token used by `espup` to query the GitHub API        | string |         _empty_         |
 
 All inputs are optional; if no inputs are provided:
 
@@ -69,21 +64,29 @@ All inputs are optional; if no inputs are provided:
 
 ## Environment
 
-This action uses [espup], which calls GitHub API during the installation process. [GitHub API has a low rate limit] for non-authenticated users, and this can lead to transient errors. See [#15] for details.
+This action uses [espup], which calls the GitHub API during the installation process. [GitHub API has a low rate limit] for non-authenticated users, and this can lead to transient errors. See [#15] for details.
 
-So, we recommend [defining] `GITHUB_TOKEN`, as seen in the [example workflow], which increases the rate limit to 1000.
+The token passed to `espup` is the first non-empty value of:
+
+1. the `github-token` input,
+2. the `GITHUB_TOKEN` environment variable visible to the action, whether it comes from the workflow, job or step level, or is injected by the runner itself,
+3. the [github.token] context, i.e. the token GitHub Actions automatically provides to every workflow run.
+
+If all three are empty, `GITHUB_TOKEN` is unset before running `espup`, so the API is queried anonymously rather than with an empty `Authorization` header, which the API rejects with `401 Unauthorized`.
+
+On GitHub Actions, case 3 always applies, so no setup is required: the API queries are authenticated by default.
 
 [espup]: https://github.com/esp-rs/espup
 [GitHub API has a low rate limit]: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
 [#15]: https://github.com/esp-rs/xtensa-toolchain/issues/15
-[defining]: https://docs.github.com/en/actions/learn-github-actions/variables
-[example workflow]: #example-workflow
+[github.token]: https://docs.github.com/en/actions/concepts/security/github_token
 
 ### Third-party runners (Forgejo, Gitea)
 
-These runners inject their own `GITHUB_TOKEN` into every step, including the steps inside a composite action, which overrides any value set at the workflow, job, or step level.
+These runners inject their own `GITHUB_TOKEN`, which overrides any `GITHUB_TOKEN` you set at the workflow or job level.
+Setting it at the step level does take effect for that step, but the injection happens again for every step of a composite action like this one, so it cannot be overridden from the calling workflow.
 That token is not valid for `api.github.com`, so `espup` fails with `401 Unauthorized`.
-Pass a GitHub token through the `github-token` input instead:
+Since the injected token is only seen as case 2 above, the `github-token` input is the only way to override it:
 
 ```yaml
 - name: Install Rust for Xtensa

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This action can be configured in various ways using its inputs:
 |    `export`     |               Sources `${ESPUP_EXPORT_FILE}`               |  bool  |         `true`          |
 | `extended-llvm` | Install the whole LLVM instead of only installing the libs |  bool  |         `false`         |
 |     `name`      |                 Xtensa Rust toolchain name                 | string |          _esp_          |
+| `github-token`  |        Token used by `espup` to query the GitHub API       | string |  `${{ github.token }}`  | 
 
 All inputs are optional; if no inputs are provided:
 
@@ -78,7 +79,22 @@ So, we recommend [defining] `GITHUB_TOKEN`, as seen in the [example workflow], w
 [defining]: https://docs.github.com/en/actions/learn-github-actions/variables
 [example workflow]: #example-workflow
 
-## Use with [act]
+### Third-party runners (Forgejo, Gitea)
+
+These runners inject their own `GITHUB_TOKEN` into every step, including the steps inside a composite action, which overrides any value set at the workflow, job, or step level.
+That token is not valid for `api.github.com`, so `espup` fails with `401 Unauthorized`.
+Pass a GitHub token through the `github-token` input instead:
+
+```yaml
+- name: Install Rust for Xtensa
+  uses: esp-rs/xtensa-toolchain@v1
+  with:
+    github-token: ${{ secrets.GH_API_TOKEN }}
+    default: true
+    buildtargets: esp32s3
+```
+
+### Use with [act]
 
 [act] is a tool which can be used to run GitHub workflows locally, using Docker. It is possible to use the `xtensa-toolchain` action with [act]; however, due to the fact that [espup] queries the GitHub API, it is necessary to set the `GITHUB_TOKEN` environment variable in order to do so.
 

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,12 @@ inputs:
   esp-riscv-gcc:
     description: Install Espressif RISC-V toolchain built with croostool-ng
     default: "false"
+  github-token:
+    description: >-
+      Token used by espup to query the GitHub API. Defaults to the token
+      exposed by the CI platform. On third-party runners (Forgejo, Gitea)
+      that token is not valid for api.github.com, so pass a GitHub PAT here.
+    default: ""
 
 runs:
   using: composite
@@ -72,7 +78,12 @@ runs:
     - name: Install Xtensa toolchain (Linux, macOS)
       if: env.HOST_TARGET != 'x86_64-pc-windows-msvc'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
       run: |
+        # espup adds an Authorization header whenever GITHUB_TOKEN is *set*,
+        # even when empty, which yields a 401. Prefer unauthenticated queries.
+        if [[ -z "${GITHUB_TOKEN:-}" ]]; then unset GITHUB_TOKEN; fi
         source "$HOME/.cargo/env"
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
         [[ "${{ inputs.extended-llvm }}" = true ]] && extended_llvm="-e" || extended_llvm=""
@@ -89,7 +100,10 @@ runs:
     - name: Install Xtensa toolchain (Windows)
       if: env.HOST_TARGET == 'x86_64-pc-windows-msvc'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token || env.GITHUB_TOKEN || github.token }}
       run: |
+        if [[ -z "${GITHUB_TOKEN:-}" ]]; then unset GITHUB_TOKEN; fi
         [[ "${{ inputs.version }}" != latest ]] && version="--toolchain-version ${{ inputs.version }}" || version=""
         [[ "${{ inputs.extended-llvm }}" = true ]] && extended_llvm="-e" || extended_llvm=""
         [[ "${{ inputs.name }}" != esp ]] && name="--name ${{ inputs.name }}" || name=""


### PR DESCRIPTION
Fixes #48 

Add an optional `github-token` input for the use-case described in #48 on forgejo runner.
Based on the same work done on the [git-cliff-action](https://github.com/orhun/git-cliff-action) repo in https://github.com/orhun/git-cliff-action/pull/77 I have also added `github.token` context handling that is set by default from the [Github Documentation](https://docs.github.com/en/actions/concepts/security/github_token):

> The token is also available in the `github.token` context.

This allowed me to drop the requirement to set the environment variable in the README and in the CI workflow of this repo.

This change has been tested on my Forgejo Workflow, on Github with the env var set manually as before and without it (see actions results in my fork).

The new line `if [[ -z "${GITHUB_TOKEN:-}" ]]; then unset GITHUB_TOKEN; fi` allows to unset the env var if empty to avoid a 401 because espup does not check for an empty env var and set an empty token in the header of the request.

I have tried to update the README but you might want some changes in the wording.